### PR TITLE
Added a --dc-host option to specify the DC hostname in case 445/NTLM …

### DIFF
--- a/targetedKerberoast.py
+++ b/targetedKerberoast.py
@@ -467,7 +467,7 @@ def parse_args():
     parser.add_argument('--use-ldaps', action='store_true', help='Use LDAPS instead of LDAP')
     parser.add_argument('--only-abuse', action='store_true', help='Ignore accounts that already have an SPN and focus on targeted Kerberoasting')
     parser.add_argument('--no-abuse', action='store_true', help="Don't attempt targeted Kerberoasting")
-    parser.add_argument('--dc-host', action='store', help='Domain to query/request if different than the domain of the user. Allows for Kerberoasting across trusts.')
+    parser.add_argument('--dc-host', action='store', help='Hostname of the target, can be used if port 445 is blocked or if NTLM is disabled')
 
 
     authconn = parser.add_argument_group('authentication & connection')

--- a/targetedKerberoast.py
+++ b/targetedKerberoast.py
@@ -226,13 +226,16 @@ def init_ldap_connection(target, tls_version, use_kerberos, domain, username, pa
 
 
 def init_ldap_session(use_kerberos, use_ldaps, dc_ip, domain, username, password, lmhash, nthash):
-    if use_kerberos:
+    if use_kerberos and not args.dc_host:
         target = get_machine_name(dc_ip, domain)
     else:
-        if dc_ip is not None:
-            target = args.dc_ip
+        if use_kerberos:
+            target = args.dc_host
         else:
-            target = domain
+            if dc_ip is not None:
+                target = args.dc_ip
+            else:
+                target = domain
 
     if use_ldaps is True:
         try:
@@ -464,6 +467,8 @@ def parse_args():
     parser.add_argument('--use-ldaps', action='store_true', help='Use LDAPS instead of LDAP')
     parser.add_argument('--only-abuse', action='store_true', help='Ignore accounts that already have an SPN and focus on targeted Kerberoasting')
     parser.add_argument('--no-abuse', action='store_true', help="Don't attempt targeted Kerberoasting")
+    parser.add_argument('--dc-host', action='store', help='Domain to query/request if different than the domain of the user. Allows for Kerberoasting across trusts.')
+
 
     authconn = parser.add_argument_group('authentication & connection')
     authconn.add_argument('--dc-ip', action='store', metavar="ip address", help='IP Address of the domain controller or KDC (Key Distribution Center) for Kerberos. If omitted it will use the domain part (FQDN) specified in the identity parameter')
@@ -526,13 +531,16 @@ def main():
 
         # First of all, we need to get a TGT for the user
         userName = Principal(args.auth_username, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-        if args.use_kerberos:
+        if args.use_kerberos and not args.dc_host:
             target = get_machine_name(args.dc_ip, args.auth_domain)
         else:
-            if args.dc_ip is not None:
-                target = args.dc_ip
+            if args.use_kerberos:
+                target = args.dc_host
             else:
-                target = args.auth_domain
+                if args.dc_ip is not None:
+                    target = args.dc_ip
+                else:
+                    target = args.auth_domain
 
         TGT = TGS = None
         if args.use_kerberos:


### PR DESCRIPTION
Hello,

The tool doesn't seem to work if NTLM is disabled or if the port 445 is blocked, it seems you are using SMB with an anonymous login to try to get the DC hostname so the end user doesn't have to specify it.

I added a `--dc-host` option to specify the DC hostname in case 445/NTLM is blocked.

```
python3 targetedKerberoast.py -v -d lab.local -k --no-pass --dc-host dc01.lab.local
```

Without that option, the tool would crash because unable to get a hostname:
```
impacket.smb3.SessionError: SMB SessionError: STATUS_NOT_SUPPORTED(The request is not supported.)
...
...
Exception: Error while anonymous logging into lab.local
```

I discovered that bug and it's explanation by doing a network capture and also by reading 2 issues/PR in Impacket:
- https://github.com/SecureAuthCorp/impacket/pull/838
- https://github.com/SecureAuthCorp/impacket/issues/817