### PR TITLE
Fixed deprecation warning concerning `datetime.datetime.utcnow()`

### DIFF
--- a/targetedKerberoast.py
+++ b/targetedKerberoast.py
@@ -163,7 +163,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     authenticator['authenticator-vno'] = 5
     authenticator['crealm'] = domain
     seq_set(authenticator, 'cname', userName.components_to_asn1)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     authenticator['cusec'] = now.microsecond
     authenticator['ctime'] = KerberosTime.to_asn1(now)


### PR DESCRIPTION
Hi @ShutdownRepo 

This PR fixes a deprecation warning concerning `datetime.datetime.utcnow()`. The function is deprecated and prints a warning with Python 3.12+.

```
/home/user/repos/targetedKerberoast/targetedKerberoast.py:166: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  now = datetime.datetime.utcnow()
```