### PR TITLE
Add -f/--output-format option for hashcat and john formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ optional arguments:
                         Requests TGS for the SPN associated to the user specified (just the username, no domain needed)
   -o OUTPUT_FILE, --output-file OUTPUT_FILE
                         Output filename to write ciphers in JtR/hashcat format
+  -f {hashcat,john}, --output-format {hashcat,john}
+                        Output format (default is "hashcat", "john" prepends usernames)
   --use-ldaps           Use LDAPS instead of LDAP
   --only-abuse          Ignore accounts that already have an SPN and focus on targeted Kerberoasting
   --no-abuse            Don't attempt targeted Kerberoasting

--- a/targetedKerberoast.py
+++ b/targetedKerberoast.py
@@ -341,6 +341,9 @@ def obtain_krb_hash(TGT, sAMAccountName, target_domain, kdc_host):
 
 def handle_result(filename, result, user):
     if result is not None:
+        # Prepend the username for better output with john
+        if args.output_format == 'john':
+            result = user + ':' + result
         if filename is not None and filename != '':
             if len(os.path.dirname(filename)) != 0:
                 if not os.path.exists(os.path.dirname(filename)):
@@ -467,6 +470,7 @@ def parse_args():
     parser.add_argument('-U', '--users-file', help='File with user per line to test')
     parser.add_argument('--request-user', action='store', metavar='username', help='Requests TGS for the SPN associated to the user specified (just the username, no domain needed)')
     parser.add_argument('-o', '--output-file', action='store', help='Output filename to write ciphers in JtR/hashcat format')
+    parser.add_argument('-f', '--output-format', action='store', choices=['hashcat', 'john'], default='hashcat', help='Output format (default is "hashcat", "john" prepends usernames)')
     parser.add_argument('--use-ldaps', action='store_true', help='Use LDAPS instead of LDAP')
     parser.add_argument('--only-abuse', action='store_true', help='Ignore accounts that already have an SPN and focus on targeted Kerberoasting')
     parser.add_argument('--no-abuse', action='store_true', help="Don't attempt targeted Kerberoasting")


### PR DESCRIPTION
As per #12, this adds the `-f` or `--output-format` option. The default value is `hashcat`, which keeps the current behaviour. The `john` value prepends the username with a colon at the start out the output (both in stdout and in any output file):

```
$ ./targetedKerberoast.py -d domain.local -u Admin -p [...]
[+] Printing hash for (myuser)
$krb5tgs$23$*myuser$DOMAIN.LOCAL$domain.local/myuser*$4d38994ee091d248a65786da342fcb3e$85[...]


$ ./targetedKerberoast.py -d domain.local -u Admin -p [...] --output-format john
[+] Printing hash for (myuser)
myuser:$krb5tgs$23$*myuser$DOMAIN.LOCAL$domain.local/myuser*$41e4304c0822e63e8ccd275f07f0ce36$93[...]
```

Which means that username will be shown in John's output when cracking and viewing hashes rather than just a `?` symbol:

```
$ john kerb.txt
[...]
Password1        (myuser)

$ john --show kerb.txt
myuser:Password1
```

Given how small the change the difference is it seemed easiest to just add it into `handle_result()` - if there are other output changes with bigger changes in future then it should probably be done in `obtain_krb_hash()` instead to give more flexibility. But I can't think of any other formats that would be needed or useful.