### PR TITLE
Adjusted anonymous login Exception, for more user-friendly guidance

### DIFF
--- a/targetedKerberoast.py
+++ b/targetedKerberoast.py
@@ -32,7 +32,7 @@ def get_machine_name(dc_ip, domain):
         s.login('', '')
     except Exception:
         if s.getServerName() == '':
-            raise Exception('Error while anonymous logging into %s' % domain)
+            raise Exception('[%s] Anonymous login failure: -- Try providing the --dc-host argument' % domain)
     else:
         s.logoff()
     return s.getServerName()
@@ -474,7 +474,7 @@ def parse_args():
     parser.add_argument('--use-ldaps', action='store_true', help='Use LDAPS instead of LDAP')
     parser.add_argument('--only-abuse', action='store_true', help='Ignore accounts that already have an SPN and focus on targeted Kerberoasting')
     parser.add_argument('--no-abuse', action='store_true', help="Don't attempt targeted Kerberoasting")
-    parser.add_argument('--dc-host', action='store', help='Hostname of the target, can be used if port 445 is blocked or if NTLM is disabled')
+    parser.add_argument('--dc-host', action='store', help='Hostname of the target, Required if port 445 is blocked or if NTLM is disabled')
 
 
     authconn = parser.add_argument_group('authentication & connection')


### PR DESCRIPTION
Small adjustment that helps with usability.  When you have more than like 5 cli options, it helps to guide the user to other helpful options. Rather than hoping they read the -h properly as intended.
```
raise Exception('Error while anonymous logging into %s' % domain)
vs.
raise Exception('[%s] Anonymous login failure: -- Try providing the --dc-host argument' % domain)
```
I encountered this and was very confused, having specified the -d and the -D options, only to look in the code to see it was simply the --dc-host option I needed, but there was no help in the error message. 
I could make a more sensible default, but that would require more scrutiny than a slight clarity adjustment.